### PR TITLE
Fixed broken how to contribute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ Later we will prepare tutorials of how to make widgets which are not available i
 
 * Share this website to social media
 * Star our repository [github.com/materialdoc](https://github.com/materialdoc/materialdoc-web)
-* Write or edit article and send pull request to `master` branch. *(Make sure you have read [how to contribute](/how-to-contribute) section)*
+* Write or edit article and send pull request to `master` branch. *(Make sure you have read [how to contribute](docs/how-to-contribute.md) section)*
 


### PR DESCRIPTION
This fix sets the link for `md` file in `github`, should we set it to https://materialdoc.com/how-to-contribute/ ?

Related to #11 
