### PR TITLE
Add additional note about using TextInputEditText

### DIFF
--- a/docs/components/text-fields.md
+++ b/docs/components/text-fields.md
@@ -150,7 +150,7 @@ III. Declare your `EditText` inside any `layout.xml` file and wrap it with `Text
 ```
 
 !!! note
-    Both widgets `TextInputLayout` and `EditText` have `android:hint` attribute, you can use any of them.
+    Both widgets `TextInputLayout` and `EditText` have `android:hint` attribute, you can use any of them. If your app supports landscape mode, replace `EditText` with `TextInputEditText` in order for the hint to display correctly.
 
 ### How to style?
 


### PR DESCRIPTION
When adding a `TextInputLayout` with a floating label hint in landscape mode, the hint will only display correctly if a `TextInputEditText` is used instead of a regular `EditText`. [The official docs refer to "extract mode"](https://developer.android.com/reference/android/support/design/widget/TextInputEditText.html), which is when the EditText has focus in landscape mode and takes up the entire screen.