### PR TITLE
Declared inputType for Password Toggle

### DIFF
--- a/docs/components/text-fields.md
+++ b/docs/components/text-fields.md
@@ -373,6 +373,7 @@ III. Declare your `EditText` inside any `layout.xml` file and wrap it with `Text
     <EditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:inputType="textPassword"
         android:hint="Password" />
 
 </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
Password toggle worked for me by adding `android:inputType="textPassword"` to the EditText.