### PR TITLE
Cannot resolve symbol dogsArr in example

### DIFF
--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -38,7 +38,7 @@ III. Define a `filterable list adapter` to manage the auto completion data list.
 
 ```java
 int layoutItemId = android.R.layout.simple_dropdown_item_1line;
-String[] dogArr = getResources().getStringArray(R.array.dogs_list);
+String[] dogsArr = getResources().getStringArray(R.array.dogs_list);
 List<String> dogList = Arrays.asList(dogsArr);
 ArrayAdapter<String> adapter = new ArrayAdapter<>(this, layoutItemId, dogList);
 


### PR DESCRIPTION
Array of dog names was declared as dogArr, but then in the next line, called as dogsArr, resulting in the error, "Cannot resolve symbol dogsArr" in android studio. 

Since the variable references multiple values, i renamed the initial reference dogArr to dogsArr, for consistency.